### PR TITLE
fix exporting multiple components

### DIFF
--- a/URDF_Exporter/utils/utils.py
+++ b/URDF_Exporter/utils/utils.py
@@ -15,39 +15,38 @@ def copy_occs(root):
     """    
     duplicate all the components
     """    
-    def copy_body(allOccs, old_occs):
+    def copy_body(allOccs, occs):
         """    
         copy the old occs to new component
         """
         
-        bodies = old_occs.bRepBodies
+        bodies = occs.bRepBodies
         transform = adsk.core.Matrix3D.create()
-        old_component_name = old_occs.component.name
         
         # Create new components from occs
         # This support even when a component has some occses. 
-        same_occs = []  
-        for occs in allOccs:
-            if occs.component.name == old_component_name:
-                same_occs.append(occs)
-        for occs in same_occs:
-            new_occs = allOccs.addNewComponent(transform)  # this create new occs
-            if occs.component.name == 'base_link':
-                old_occs.component.name = 'old_component'
-                new_occs.component.name = 'base_link'
-            else:
-                new_occs.component.name = re.sub('[ :()]', '_', occs.name)
-            new_occs = allOccs[-1]
-            for i in range(bodies.count):
-                body = bodies.item(i)
-                body.copyToComponent(new_occs)
-        old_occs.component.name = 'old_component'
-        
+
+        new_occs = allOccs.addNewComponent(transform)  # this create new occs
+        if occs.component.name == 'base_link':
+            occs.component.name = 'old_component'
+            new_occs.component.name = 'base_link'
+        else:
+            new_occs.component.name = re.sub('[ :()]', '_', occs.name)
+        new_occs = allOccs[-1]
+        for i in range(bodies.count):
+            body = bodies.item(i)
+            body.copyToComponent(new_occs)
+    
     allOccs = root.occurrences
+    oldOccs = []
     coppy_list = [occs for occs in allOccs]
     for occs in coppy_list:
         if occs.bRepBodies.count > 0:
             copy_body(allOccs, occs)
+            oldOccs.append(occs)
+
+    for occs in oldOccs:
+        occs.component.name = 'old_component'
 
 
 def export_stl(design, save_dir, components):  


### PR DESCRIPTION
Multiple changes to utils/utils.py to support exporting multiple copies of components:
1.  moved renaming old components to outside of copy_body, after all copies complete (otherwise you're renaming a copy of a component before you're finished, which affects all copies of that component)
2.  removed all the same_occs code (not necessary, and I think that's the reason that the method was creating X^2 old_components when there were multiple copies)
3.  renamed old_occs parameter to occs to avoid confusion with oldOccs array.
4.  you will definitely see a speedup. :-)

simple test design uploaded here:
https://drive.google.com/open?id=1AGhEM4f63KbEJ8FhI6pkWpO6sjfRcVbK

Before this change, running the script would result in 16 copies of occuranced_link, and the four new components occuranced_link_1-4 would be overlaid over each other in the first position (among other things).

After this change, only one copy of each occuranced_link_1-4 is created, and each component is correctly positioned and exported even if it is one of multiple copies.

I've only tested out this change on two designs. I'd suggest testing it out yourself on a few different models, but the logic looks good, and it's working great for me.

Thanks!

Alan