### PR TITLE
end exporting of old_components

### DIFF
--- a/URDF_Exporter/utils/utils.py
+++ b/URDF_Exporter/utils/utils.py
@@ -71,22 +71,21 @@ def export_stl(design, save_dir, components):
     scriptDir = save_dir + '/mm_stl'  
     # export the occurrence one by one in the component to a specified file
     for component in components:
-        if 'old' in component.name:
-            continue
         allOccus = component.allOccurrences
         for occ in allOccus:
-            try:
-                print(occ.component.name)
-                fileName = scriptDir + "/" + occ.component.name              
-                # create stl exportOptions
-                stlExportOptions = exportMgr.createSTLExportOptions(occ, fileName)
-                stlExportOptions.sendToPrintUtility = False
-                stlExportOptions.isBinaryFormat = False
-                # options are .MeshRefinementLow .MeshRefinementMedium .MeshRefinementHigh
-                stlExportOptions.meshRefinement = adsk.fusion.MeshRefinementSettings.MeshRefinementMedium
-                exportMgr.execute(stlExportOptions)
-            except:
-                print('Component ' + occ.component.name + 'has something wrong.')
+            if 'old_component' not in occ.component.name:
+                try:
+                    print(occ.component.name)
+                    fileName = scriptDir + "/" + occ.component.name              
+                    # create stl exportOptions
+                    stlExportOptions = exportMgr.createSTLExportOptions(occ, fileName)
+                    stlExportOptions.sendToPrintUtility = False
+                    stlExportOptions.isBinaryFormat = False
+                    # options are .MeshRefinementLow .MeshRefinementMedium .MeshRefinementHigh
+                    stlExportOptions.meshRefinement = adsk.fusion.MeshRefinementSettings.MeshRefinementLow
+                    exportMgr.execute(stlExportOptions)
+                except:
+                    print('Component ' + occ.component.name + 'has something wrong.')
                 
 
 def file_dialog(ui):     


### PR DESCRIPTION
added in a check for "old_component" and if seen skip exporting that component.

This is more of a judgement call, not sure if you were intentionally exporting the old_components or not, but this will skip the export if the name contains "old_component".

It should work pretty well unless someone names their component "*old_component*".  
¯\_(ツ)_/¯

Thanks!

Alan