### PR TITLE
remove unit conversion in axis

### DIFF
--- a/URDF_Exporter/core/Joint.py
+++ b/URDF_Exporter/core/Joint.py
@@ -154,7 +154,7 @@ def make_joints_dict(root, msg):
                 
         elif joint_type == 'prismatic':
             joint_dict['axis'] = [round(i, 6) for i in \
-                joint.jointMotion.slideDirectionVector.asArray()]  #TODO: Not tested yet. Will this be also normalized?
+                joint.jointMotion.slideDirectionVector.asArray()]  # Also normalized
             max_enabled = joint.jointMotion.slideLimits.isMaximumValueEnabled
             min_enabled = joint.jointMotion.slideLimits.isMinimumValueEnabled            
             if max_enabled and min_enabled:  

--- a/URDF_Exporter/core/Joint.py
+++ b/URDF_Exporter/core/Joint.py
@@ -136,8 +136,8 @@ def make_joints_dict(root, msg):
         
         # support  "Revolute", "Rigid" and "Slider"
         if joint_type == 'revolute':
-            joint_dict['axis'] = [round(i / 100.0, 6) for i in \
-                joint.jointMotion.rotationAxisVector.asArray()]  # converted to meter
+            joint_dict['axis'] = [round(i, 6) for i in \
+                joint.jointMotion.rotationAxisVector.asArray()] ## In Fusion, exported axis is normalized.
             max_enabled = joint.jointMotion.rotationLimits.isMaximumValueEnabled
             min_enabled = joint.jointMotion.rotationLimits.isMinimumValueEnabled            
             if max_enabled and min_enabled:  
@@ -153,8 +153,8 @@ def make_joints_dict(root, msg):
                 joint_dict['type'] = 'continuous'
                 
         elif joint_type == 'prismatic':
-            joint_dict['axis'] = [round(i / 100.0, 6) for i in \
-                joint.jointMotion.slideDirectionVector.asArray()]  # converted to meter
+            joint_dict['axis'] = [round(i, 6) for i in \
+                joint.jointMotion.slideDirectionVector.asArray()]  #TODO: Not tested yet. Will this be also normalized?
             max_enabled = joint.jointMotion.slideLimits.isMaximumValueEnabled
             min_enabled = joint.jointMotion.slideLimits.isMinimumValueEnabled            
             if max_enabled and min_enabled:  


### PR DESCRIPTION
For rotationAxisVector exported in Fusion, it is a normalized vector indicating the rotation axis. So theoretically the unit conversion is not needed here.

I am a Pybullet user and the unit conversion indeed cause a problem during simulation. The 0.01 scale do matters in Pybullet, and will cause the joints moves 100 times slower than expected.

I'm not sure how gazebo deal with the rotation axis numbers.  Maybe someone will be interested in testing that?