### PR TITLE
Fix index error

### DIFF
--- a/URDF_Exporter/utils/utils.py
+++ b/URDF_Exporter/utils/utils.py
@@ -34,7 +34,7 @@ def copy_occs(root):
             new_occs.component.name = 'base_link'
         else:
             new_occs.component.name = re.sub('[ :()]', '_', occs.name)
-        new_occs = allOccs[-1]
+        new_occs = allOccs.item((allOccs.count-1))
         for i in range(bodies.count):
             body = bodies.item(i)
             body.copyToComponent(new_occs)


### PR DESCRIPTION
Fusion API changed in the way occurence items are accessed. It is no Python list anymore. The item method allows now acccessing the occurence objects