### PR TITLE
Adapter to ROS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Make sure z axis is upright in your fusion 360 model if you want.
 
 ## Before using this script
 
+在使用此脚本进行转换之前，第一步需要做的就是简化简化模型（link连杆）。在 fusion360 中可以使用合并实体的方式将多个零件中的多个实体（保持关节部分活动即可，其余复杂细合并/删除）通过布尔运算合并为一个大的实体，再把零部件使用 "联接" 装配起来，然后把基准参考零部件的名称重命名为 "base_link"。
+
+> 在定义关节时将 "base_link" 定义为 Component1 时 **父链接** 应设置为Component2，否则会出现 “KeyError: base_link__1” 错误。
+> 
+> 没有定义 "base_link" 或没有使用"联接" 装配运行脚本无法转换或无反应。
+
 Before using this script, make sure that your model has all the "links" as components. You have to define the links by creating corresiponding components. For example, this model(https://grabcad.com/library/spotmini-robot-1) is not supported unless you define the "base_link". 
 
 In addition to that, you should be careful when define your joints. The **parent links** should be set as **Component2** when you define the joint, not as Component1. For example, if you define the "base_link" as Component1 when you define the joints, an error saying "KeyError: base_link__1" will show up.

--- a/README.md
+++ b/README.md
@@ -3,27 +3,41 @@
 This is a **fork** of the original [syuntoku14/fusion2urdf](https://github.com/syuntoku14/fusion2urdf) repository. 
 
 ## **Changes Made**
+
 - **Python 3.12 Compatibility**: Replaced the deprecated `distutils.dir_util` with `shutil` for directory operations, ensuring compatibility with **Python 3.12** used by Fusion 360.
 - **Error Handling**: Improved error handling to prevent `FileExistsError` when copying directories if they already exist.
 - **Directory Operations**: All directory copying is now done using `shutil.copytree`.
 
 ## **Notes**
+
 - The script is updated for use with **Python 3.12**, as Fusion 360 no longer supports `distutils` in versions above Python 3.10.
 
 ---
 
-
-
 ## Updated!!!
+
+- 2026/0319:Will migrate to Fusion:v.2606.1.36, and ROS2
+  
+  * Modify the Write.py file to adapt to the ROS2 xacro file format
+  
+  * The delete Node function does not support the `required` parameter
+  
+  * Replace the ROS1 `rviz_class_name` in urdf.rviz with the ROS2 `rviz_default_plugins/`
+  
+  * Use RViz2 to regenerate a urdf belonging to ROS2 with a new rviz configuration
 * 2021/01/09: Fix xyz calculation. 
+  
   * If you see that your components move arround the map center in rviz try this update 
   * More Infos see: https://forums.autodesk.com/t5/fusion-360-api-and-scripts/difference-of-geometryororiginone-and-geometryororiginonetwo/m-p/9837767
 
 * 2020/11/10: README fix
+  
   * MacOS Installation command fixed in README
   * Date format unified in README to yyyy/dd/mm
   * Shifted Installation Upwards for better User Experience and easier to find
+
 * 2020/01/04: Multiple updates:
+  
   * no longer a need to run a bash script to convert stls
   * some cleanup around joint and transmission generation
   * defines a sample material tag instead of defining a material in each link
@@ -31,10 +45,12 @@ This is a **fork** of the original [syuntoku14/fusion2urdf](https://github.com/s
   * now launched by roslaunch {robot_name}_description display.launch
   * changed fusion2urdf output from urdf to xacro for more flexibility
   * separate out material, transmissions, gazebo elements to separate files
-* 2018/20/10: Fixed functions to generate launch files
-* 2018/25/09: Supports joint types "Rigid", "Slider" & Supports the joints' limit(for "Revolute" and "Slider"). 
-* 2018/19/09: Fixed the bugs about the center of the mass and the inertia.
 
+* 2018/20/10: Fixed functions to generate launch files
+
+* 2018/25/09: Supports joint types "Rigid", "Slider" & Supports the joints' limit(for "Revolute" and "Slider"). 
+
+* 2018/19/09: Fixed the bugs about the center of the mass and the inertia.
 
 ## Installation
 
@@ -55,31 +71,37 @@ cp -r ./URDF_Exporter "$HOME/Library/Application Support/Autodesk/Autodesk Fusio
 ```
 
 ## What is this script?
+
 This is a fusion 360 script to export urdf from fusion 360 directly.
 
 This exports:
+
 * .urdf file of your model
 * .launch and .yaml files to simulate your robot on gazebo
 * .stl files of your model
 
-### Sample 
+### Sample
 
 The following test model doesn't stand upright because the z axis is not upright in default fusion 360.
 Make sure z axis is upright in your fusion 360 model if you want. 
 
 #### original model
+
 <img src="https://github.com/syuntoku14/fusion2urdf/blob/images/industrial_robot.png" alt="industrial_robot" title="industrial_robot" width="300" height="300">
 
 #### Gazebo simulation of exported .urdf and .launch
+
 * center of mass
-<img src="https://github.com/syuntoku14/fusion2urdf/blob/images/center_of_mass.png" alt="center_of_mass" title="center_of_mass" width="300" height="300">
+  
+  <img src="https://github.com/syuntoku14/fusion2urdf/blob/images/center_of_mass.png" alt="center_of_mass" title="center_of_mass" width="300" height="300">
 
 * collision
-<img src="https://github.com/syuntoku14/fusion2urdf/blob/images/collision.png" alt="collision" title="collision" width="300" height="300">
+  
+  <img src="https://github.com/syuntoku14/fusion2urdf/blob/images/collision.png" alt="collision" title="collision" width="300" height="300">
 
 * inertia
-<img src="https://github.com/syuntoku14/fusion2urdf/blob/images/inertia.png" alt="inertia" title="inertia" width="300" height="300">
-
+  
+  <img src="https://github.com/syuntoku14/fusion2urdf/blob/images/inertia.png" alt="inertia" title="inertia" width="300" height="300">
 
 ## Before using this script
 
@@ -101,7 +123,6 @@ but this doesn't work since the "face (3):1" component contains other components
 Sometimes this script exports abnormal urdf without any error messages. In that case, the joints should have problems. Redefine the joints and run again.
 
 In addition to that, make sure that this script currently supports only "Rigid", "Slider" and "Revolute".
-
 
 ## Complex Kinematic Loops and Spherical joints (may be fixed later):
 
@@ -126,9 +147,7 @@ Below you can see one of the cylinders is mismatched as compared to the others (
 
 See Also: Similar to this issue, but only for a few axes [here](https://github.com/yanshil/Fusion2PyBullet/issues/6) (turns out there was a fusion API change back then, and the exporter wasn't yet updated [See this commit](https://github.com/syuntoku14/fusion2urdf/commit/8786e6318cdcaaf32070148451a27ab6e4f6697d), but it now is)
 
-
 **The fix for this is to leave Fusion's joint controls unedited and form joints for the robot joints (See below)**
-
 
 A similar issue with another set of joints at the ankle was fixed by following the above fromat. [Here is the video](https://www.youtube.com/watch?v=0hfkm7vv5o8&ab_channel=JRohit)
 
@@ -137,19 +156,16 @@ The ankle joint below has 4 spherical joints and only two of them were defined a
 
 ![youtube-video-gif](https://user-images.githubusercontent.com/37873142/133144404-45d9e444-8ddb-4b5f-8970-6e637b750faa.gif)
 
-
 ## In some cases, before export Turn off "Capture design history"
 
 For preplanning the component placement when working/assembling your own robot. It is recomended to have separate names for components and save individual components in a separate folder, create a back up and, break link with the original. This folder can be later deleted after genearating the urdf. See [Issue #51](https://github.com/syuntoku14/fusion2urdf/issues/51) for problem with "copy-paste" vs "copy-paste new".
-
-
 
 ## How to use
 
 As an example, I'll export a urdf file from this cool fusion360 robot-arm model(https://grabcad.com/library/industrial-robot-10).
 This was created by [sanket patil](https://grabcad.com/sanket.patil-16)
 
-### Install in Shell 
+### Install in Shell
 
 Run the [installation command](#installation) in your shell.
 
@@ -180,7 +196,6 @@ You have successfully exported the urdf file. Also, you got `.stl` files in the 
 
 The folder "Desktop/test" will be required in the next step. Move them into your ros environment.
 
-
 #### In your ROS environment
 
 Place the generated _description package directory in your own ROS workspace. "catkin_ws" is used in this example.
@@ -201,13 +216,12 @@ roslaunch (whatever your robot_name is)_description display.launch
 <img src="https://github.com/syuntoku14/fusion2urdf/blob/images/rviz_robot.png" alt="rviz" title="rviz" width="300" height="300">
 
 If you want to simulate your robot on gazebo, just run
+
 ```bash
 roslaunch (whatever your robot_name is)_description gazebo.launch
 ```
 
 **Enjoy your Fusion 360 and ROS life!**
-
-
 
 # Citation
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ This exports:
 * .urdf file of your model
 * .launch and .yaml files to simulate your robot on gazebo
 * .stl files of your model
+* 注意实际导出的文件是 .xacro 后缀，虽然是 .xacro 后缀，
+  但它只是一个 .xacro 文件格式的 URDF（主体内容是普通 URDF），而不是大量参数化、宏封装后的 xacro 写法。
 
 ### Sample
 

--- a/URDF_Exporter/core/Joint.py
+++ b/URDF_Exporter/core/Joint.py
@@ -61,9 +61,16 @@ class Joint:
         if self.type == 'revolute' or self.type == 'prismatic':
             limit = SubElement(joint, 'limit')
             limit.attrib = {'upper': str(self.upper_limit), 'lower': str(self.lower_limit),
-                            'effort': '100', 'velocity': '100'}
+                            'effort': '100.0', 'velocity': '100.0'}
             
         self.joint_xml = "\n".join(utils.prettify(joint).split("\n")[1:])
+
+        '''
+        创建的关节限制参数为整形，MoveIt Setup Assistant 按照这个整形写入joint_limits.yaml文件，
+        但是MoveIt2严格要求max_velocity和max_acceleration是double浮点数。
+        但是YAML文件写的是整数 100 而不是 100.0，YAML解析器会把它标记为int型。ROS2发现类型不匹配，
+        拒绝自动转换并抛出XML_ERROR_EMPTY_DOCUMENT异常。
+        '''
 
     def make_transmission_xml(self):
         """

--- a/URDF_Exporter/core/Write.py
+++ b/URDF_Exporter/core/Write.py
@@ -128,11 +128,10 @@ def write_urdf(joints_dict, links_xyz_dict, inertial_dict, package_name, robot_n
         f.write('<?xml version="1.0" ?>\n')
         f.write('<robot name="{}" xmlns:xacro="http://www.ros.org/wiki/xacro">\n'.format(robot_name))
         f.write('\n')
-        f.write('<xacro:include filename="$(find {})/urdf/materials.xacro" />'.format(package_name))
-        f.write('\n')
-        f.write('<xacro:include filename="$(find {})/urdf/{}.trans" />'.format(package_name, robot_name))
-        f.write('\n')
-        f.write('<xacro:include filename="$(find {})/urdf/{}.gazebo" />'.format(package_name, robot_name))
+        # ROS2: use relative paths so xacro resolves from same directory when launch passes full path
+        f.write('<xacro:include filename="materials.xacro" />\n')
+        f.write('<xacro:include filename="{}.trans" />\n'.format(robot_name))
+        f.write('<xacro:include filename="{}.gazebo" />\n'.format(robot_name))
         f.write('\n')
 
     write_link_urdf(joints_dict, repo, links_xyz_dict, file_name, inertial_dict)
@@ -221,7 +220,7 @@ def write_gazebo_xacro(joints_dict, links_xyz_dict, inertial_dict, package_name,
 
         gazebo = Element('gazebo')
         plugin = SubElement(gazebo, 'plugin')
-        plugin.attrib = {'name':'control', 'filename':'libgazebo_ros_control.so'}
+        plugin.attrib = {'name':'control', 'filename':'libgazebo_ros2_control.so'}
         gazebo_xml = "\n".join(utils.prettify(gazebo).split("\n")[1:])
         f.write(gazebo_xml)
 
@@ -250,191 +249,170 @@ def write_gazebo_xacro(joints_dict, links_xyz_dict, inertial_dict, package_name,
 
 def write_display_launch(package_name, robot_name, save_dir):
     """
-    write display launch file "save_dir/launch/display.launch"
-
-
-    Parameter
-    ---------
-    robot_name: str
-    name of the robot
-    save_dir: str
-    path of the repository to save
-    """   
+    Write ROS2 display launch file "save_dir/launch/display_launch.py"
+    """
     try: os.mkdir(save_dir + '/launch')
-    except: pass     
+    except: pass
 
-    launch = Element('launch')     
+    file_name = save_dir + '/launch/display_launch.py'
+    content = '''# ROS2 launch file for displaying URDF in RViz2
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import Command, LaunchConfiguration
+from launch_ros.actions import Node
 
-    arg1 = SubElement(launch, 'arg')
-    arg1.attrib = {'name':'model', 'default':'$(find {})/urdf/{}.xacro'.format(package_name, robot_name)}
 
-    arg2 = SubElement(launch, 'arg')
-    arg2.attrib = {'name':'gui', 'default':'true'}
+def generate_launch_description():
+    pkg_share = get_package_share_directory('{package_name}')
+    default_model = os.path.join(pkg_share, 'urdf', '{robot_name}.xacro')
+    default_rviz = os.path.join(pkg_share, 'launch', 'urdf.rviz')
 
-    arg3 = SubElement(launch, 'arg')
-    arg3.attrib = {'name':'rvizconfig', 'default':'$(find {})/launch/urdf.rviz'.format(package_name)}
+    model_arg = DeclareLaunchArgument(name='model', default_value=default_model, description='Path to robot xacro')
+    rvizconfig_arg = DeclareLaunchArgument(name='rvizconfig', default_value=default_rviz, description='Path to rviz config')
 
-    param1 = SubElement(launch, 'param')
-    param1.attrib = {'name':'robot_description', 'command':'$(find xacro)/xacro $(arg model)'}
+    robot_description = Command(['xacro ', LaunchConfiguration('model')])
 
-    param2 = SubElement(launch, 'param')
-    param2.attrib = {'name':'use_gui', 'value':'$(arg gui)'}
+    robot_state_publisher_node = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        parameters=[{{'robot_description': robot_description}}]
+    )
+    joint_state_publisher_node = Node(
+        package='joint_state_publisher_gui',
+        executable='joint_state_publisher_gui'
+    )
+    rviz_node = Node(
+        package='rviz2',
+        executable='rviz2',
+        arguments=['-d', LaunchConfiguration('rvizconfig')],
+        required=True
+    )
 
-    node1 = SubElement(launch, 'node')
-    node1.attrib = {'name':'joint_state_publisher_gui', 'pkg':'joint_state_publisher_gui', 'type':'joint_state_publisher_gui'}
-
-    node2 = SubElement(launch, 'node')
-    node2.attrib = {'name':'robot_state_publisher', 'pkg':'robot_state_publisher', 'type':'robot_state_publisher'}
-
-    node3 = SubElement(launch, 'node')
-    node3.attrib = {'name':'rviz', 'pkg':'rviz', 'args':'-d $(arg rvizconfig)', 'type':'rviz', 'required':'true'}
-
-    launch_xml = "\n".join(utils.prettify(launch).split("\n")[1:])        
-
-    file_name = save_dir + '/launch/display.launch'    
+    return LaunchDescription([
+        model_arg,
+        rvizconfig_arg,
+        robot_state_publisher_node,
+        joint_state_publisher_node,
+        rviz_node,
+    ])
+'''.format(package_name=package_name, robot_name=robot_name)
     with open(file_name, mode='w') as f:
-        f.write(launch_xml)
+        f.write(content)
 
 def write_gazebo_launch(package_name, robot_name, save_dir):
     """
-    write gazebo launch file "save_dir/launch/gazebo.launch"
-    
-    
-    Parameter
-    ---------
-    robot_name: str
-        name of the robot
-    save_dir: str
-        path of the repository to save
+    Write ROS2 Gazebo launch file "save_dir/launch/gazebo_launch.py"
     """
-    
     try: os.mkdir(save_dir + '/launch')
-    except: pass     
-    
-    launch = Element('launch')
-    param = SubElement(launch, 'param')
-    param.attrib = {'name':'robot_description', 'command':'$(find xacro)/xacro $(find {})/urdf/{}.xacro'.format(package_name, robot_name)}
+    except: pass
 
-    node = SubElement(launch, 'node')
-    node.attrib = {'name':'spawn_urdf', 'pkg':'gazebo_ros', 'type':'spawn_model',\
-                    'args':'-param robot_description -urdf -model {}'.format(robot_name)}
-
-    include_ =  SubElement(launch, 'include')
-    include_.attrib = {'file':'$(find gazebo_ros)/launch/empty_world.launch'}        
-    
-    number_of_args = 5
-    args = [None for i in range(number_of_args)]
-    args_name_value_pairs = [['paused', 'true'], ['use_sim_time', 'true'],
-                             ['gui', 'true'], ['headless', 'false'], 
-                             ['debug', 'false']]
-                             
-    for i, arg in enumerate(args):
-        arg = SubElement(include_, 'arg')
-        arg.attrib = {'name' : args_name_value_pairs[i][0] , 
-        'value' : args_name_value_pairs[i][1]}
+    file_name = save_dir + '/launch/gazebo_launch.py'
+    content = '''# ROS2 launch file for Gazebo simulation
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command
+from launch_ros.actions import Node
 
 
-    
-    launch_xml = "\n".join(utils.prettify(launch).split("\n")[1:])        
-    
-    file_name = save_dir + '/launch/' + 'gazebo.launch'    
+def generate_launch_description():
+    pkg_share = get_package_share_directory('{package_name}')
+    xacro_path = os.path.join(pkg_share, 'urdf', '{robot_name}.xacro')
+    robot_description = Command(['xacro ', xacro_path])
+
+    gazebo_share = get_package_share_directory('gazebo_ros')
+    empty_world_launch = os.path.join(gazebo_share, 'launch', 'gazebo.launch.py')
+
+    gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(empty_world_launch),
+        launch_arguments={{'paused': 'true', 'use_sim_time': 'true', 'gui': 'true'}}.items()
+    )
+    robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        parameters=[{{'robot_description': robot_description}}],
+        output='screen'
+    )
+    spawn_entity = Node(
+        package='gazebo_ros',
+        executable='spawn_entity.py',
+        arguments=['-entity', '{robot_name}'],
+        parameters=[{{'robot_description': robot_description}}],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        gazebo,
+        robot_state_publisher,
+        spawn_entity,
+    ])
+'''.format(package_name=package_name, robot_name=robot_name)
     with open(file_name, mode='w') as f:
-        f.write(launch_xml)
+        f.write(content)
 
 
 def write_control_launch(package_name, robot_name, save_dir, joints_dict):
     """
-    write control launch file "save_dir/launch/controller.launch"
-    
-    
-    Parameter
-    ---------
-    robot_name: str
-        name of the robot
-    save_dir: str
-        path of the repository to save
-    joints_dict: dict
-        information of the joints
+    Write ROS2 control launch file "save_dir/launch/controller_launch.py"
     """
-    
     try: os.mkdir(save_dir + '/launch')
-    except: pass     
-    
-    #launch = Element('launch')
+    except: pass
 
-    controller_name = robot_name + '_controller'
-    #rosparam = SubElement(launch, 'rosparam')
-    #rosparam.attrib = {'file':'$(find {})/launch/controller.yaml'.format(package_name),
-    #                   'command':'load'}
-                       
-    controller_args_str = ""
-    for j in joints_dict:
-        joint_type = joints_dict[j]['type']
-        if joint_type != 'fixed':
-            controller_args_str += j + '_position_controller '
-    controller_args_str += 'joint_state_controller '
+    controller_list = ['joint_state_broadcaster']
+    if any(joints_dict[j]['type'] != 'fixed' for j in joints_dict):
+        controller_list.append('position_controller')
+    controller_args_py = ', '.join(repr(c) for c in controller_list)
 
-    node_controller = Element('node')
-    node_controller.attrib = {'name':'controller_spawner', 'pkg':'controller_manager', 'type':'spawner',\
-                    'respawn':'false', 'output':'screen', 'ns':robot_name,\
-                    'args':'{}'.format(controller_args_str)}
-    
-    node_publisher = Element('node')
-    node_publisher.attrib = {'name':'robot_state_publisher', 'pkg':'robot_state_publisher',\
-                    'type':'robot_state_publisher', 'respawn':'false', 'output':'screen'}
-    remap = SubElement(node_publisher, 'remap')
-    remap.attrib = {'from':'/joint_states',\
-                    'to':'/' + robot_name + '/joint_states'}
-    
-    #launch_xml  = "\n".join(utils.prettify(launch).split("\n")[1:])   
-    launch_xml  = "\n".join(utils.prettify(node_controller).split("\n")[1:])   
-    launch_xml += "\n".join(utils.prettify(node_publisher).split("\n")[1:])   
+    file_name = save_dir + '/launch/controller_launch.py'
+    content = '''# ROS2 launch file for ros2_control / gazebo_ros2_control
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
 
-    file_name = save_dir + '/launch/controller.launch'    
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='controller_manager',
+            executable='spawner',
+            arguments=[{controller_args}],
+            output='screen',
+        ),
+    ])
+'''.format(package_name=package_name, robot_name=robot_name,
+           controller_args=controller_args_py)
     with open(file_name, mode='w') as f:
-        f.write('<launch>\n')
-        f.write('\n')
-        #for some reason ROS is very picky about the attribute ordering, so we'll bitbang this element
-        f.write('<rosparam file="$(find {})/launch/controller.yaml" command="load"/>'.format(package_name))
-        f.write('\n')
-        f.write(launch_xml)
-        f.write('\n')
-        f.write('</launch>')
+        f.write(content)
         
 
 def write_yaml(package_name, robot_name, save_dir, joints_dict):
     """
-    write yaml file "save_dir/launch/controller.yaml"
-    
-    
-    Parameter
-    ---------
-    robot_name: str
-        name of the robot
-    save_dir: str
-        path of the repository to save
-    joints_dict: dict
-        information of the joints
+    Write ROS2 ros2_control controller config "save_dir/config/controller.yaml"
     """
-    try: os.mkdir(save_dir + '/launch')
-    except: pass 
+    try: os.mkdir(save_dir + '/config')
+    except: pass
 
-    controller_name = robot_name + '_controller'
-    file_name = save_dir + '/launch/controller.yaml'
+    file_name = save_dir + '/config/controller.yaml'
+    joint_names = [j for j in joints_dict if joints_dict[j]['type'] != 'fixed']
     with open(file_name, 'w') as f:
-        f.write(controller_name + ':\n')
-        # joint_state_controller
-        f.write('  # Publish all joint states -----------------------------------\n')
-        f.write('  joint_state_controller:\n')
-        f.write('    type: joint_state_controller/JointStateController\n')  
-        f.write('    publish_rate: 50\n\n')
-        # position_controllers
-        f.write('  # Position Controllers --------------------------------------\n')
-        for joint in joints_dict:
-            joint_type = joints_dict[joint]['type']
-            if joint_type != 'fixed':
-                f.write('  ' + joint + '_position_controller:\n')
-                f.write('    type: effort_controllers/JointPositionController\n')
-                f.write('    joint: '+ joint + '\n')
-                f.write('    pid: {p: 100.0, i: 0.01, d: 10.0}\n')
+        f.write('# ROS2 ros2_control controller config (used with gazebo_ros2_control)\n')
+        f.write('controller_manager:\n')
+        f.write('  ros__parameters:\n')
+        f.write('    update_rate: 100  # Hz\n')
+        f.write('\n')
+        f.write('    joint_state_broadcaster:\n')
+        f.write('      type: joint_state_broadcaster/JointStateBroadcaster\n')
+        f.write('\n')
+        if joint_names:
+            f.write('    position_controller:\n')
+            f.write('      type: position_controllers/JointGroupPositionController\n')
+            f.write('      joints:\n')
+            for j in joint_names:
+                f.write('        - {}\n'.format(j))
+        f.write('\n')
 

--- a/URDF_Exporter/core/Write.py
+++ b/URDF_Exporter/core/Write.py
@@ -286,8 +286,7 @@ def generate_launch_description():
     rviz_node = Node(
         package='rviz2',
         executable='rviz2',
-        arguments=['-d', LaunchConfiguration('rvizconfig')],
-        required=True
+        arguments=['-d', LaunchConfiguration('rvizconfig')]
     )
 
     return LaunchDescription([

--- a/URDF_Exporter/package/CMakeLists.txt
+++ b/URDF_Exporter/package/CMakeLists.txt
@@ -1,197 +1,36 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.8)
 project(fusion2urdf)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  rospy
+find_package(ament_cmake REQUIRED)
+
+# Install launch files
+install(DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+  FILES_MATCHING PATTERN "*.py"
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES fusion2urdf
-#  CATKIN_DEPENDS rospy
-#  DEPENDS system_lib
+# Install URDF/xacro and config
+install(DIRECTORY urdf/
+  DESTINATION share/${PROJECT_NAME}/urdf
+)
+install(DIRECTORY config/
+  DESTINATION share/${PROJECT_NAME}/config
+  OPTIONAL
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-# include
-  ${catkin_INCLUDE_DIRS}
+# Install meshes (STL)
+install(DIRECTORY meshes/
+  DESTINATION share/${PROJECT_NAME}/meshes
+  OPTIONAL
 )
 
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/fusion2urdf.cpp
-# )
+# Install RViz config
+install(FILES launch/urdf.rviz
+  DESTINATION share/${PROJECT_NAME}/launch
+)
 
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/fusion2urdf_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_fusion2urdf.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+ament_package()

--- a/URDF_Exporter/package/launch/urdf.rviz
+++ b/URDF_Exporter/package/launch/urdf.rviz
@@ -1,5 +1,5 @@
 Panels:
-  - Class: rviz_default_plugins/Displays
+  - Class: rviz_common/Displays
     Help Height: 78
     Name: Displays
     Property Tree Widget:
@@ -7,32 +7,27 @@ Panels:
         - /Global Options1
         - /Status1
         - /RobotModel1
-        - /TF1
+        - /RobotModel1/Description Topic1
       Splitter Ratio: 0.5
-    Tree Height: 591
-  - Class: rviz_default_plugins/Selection
+    Tree Height: 563
+  - Class: rviz_common/Selection
     Name: Selection
-  - Class: rviz_default_plugins/Tool Properties
+  - Class: rviz_common/Tool Properties
     Expanded:
-      - /2D Pose Estimate1
-      - /2D Nav Goal1
+      - /2D Goal Pose1
       - /Publish Point1
     Name: Tool Properties
     Splitter Ratio: 0.5886790156364441
-  - Class: rviz_default_plugins/Views
+  - Class: rviz_common/Views
     Expanded:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: rviz_default_plugins/Time
+  - Class: rviz_common/Time
     Experimental: false
     Name: Time
     SyncMode: 0
     SyncSource: ""
-Preferences:
-  PromptSaveOnExit: true
-Toolbars:
-  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
@@ -57,307 +52,62 @@ Visualization Manager:
     - Alpha: 1
       Class: rviz_default_plugins/RobotModel
       Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
       Enabled: true
       Links:
-        2dofknuckle_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_10:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_4:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_5:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_6:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_7:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_8:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        2dofknuckle_link_9:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
         All Links Enabled: true
         Expand Joint Details: false
         Expand Link Details: false
         Expand Tree: false
+        Joint1_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Joint2and3_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Joint4_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Joint5_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Joint6_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         Link Tree Style: Links in Alphabetic Order
         base_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        bucket_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        face_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        facebracket_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        hcsr04_cans_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        hcsr04_chips_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        hcsr04_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        leg_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        leg_link_2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        leg_link_3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        leg_link_4:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        lipo_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_10:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_4:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_5:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_6:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_7:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_8:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mg90_link_9:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mpu9250_cap_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mpu9250_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        mpu9250_mpu_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        pizerow_cam_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        pizerow_con_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        pizerow_cpu_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        pizerow_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        raspicam_cam_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        raspicam_chips_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        raspicam_con_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        raspicam_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_10:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_2:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_3:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_4:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_5:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_6:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_7:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_8:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        servobottom_link_9:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        shell_link_1:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
+      Mass Properties:
+        Inertia: false
+        Mass: false
       Name: RobotModel
-      Robot Description: robot_description
       TF Prefix: ""
       Update Interval: 0
       Value: true
       Visual Enabled: true
-    - Class: rviz_default_plugins/TF
-      Enabled: false
-      Frame Timeout: 15
-      Frames:
-        All Enabled: true
-      Marker Scale: 0.5
-      Name: TF
-      Show Arrows: true
-      Show Axes: true
-      Show Names: true
-      Tree:
-        {}
-      Update Interval: 0
-      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Default Light: true
     Fixed Frame: base_link
     Frame Rate: 30
   Name: root
@@ -368,47 +118,66 @@ Visualization Manager:
     - Class: rviz_default_plugins/Select
     - Class: rviz_default_plugins/FocusCamera
     - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
-      Theta std deviation: 0.2617993950843811
-      Topic: /initialpose
-      X std deviation: 0.5
-      Y std deviation: 0.5
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
     - Class: rviz_default_plugins/SetGoal
-      Topic: /move_base_simple/goal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
     - Class: rviz_default_plugins/PublishPoint
       Single click: true
-      Topic: /clicked_point
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
   Value: true
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 0.34426525235176086
+      Distance: 0.904883861541748
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.0016349668148905039
-        Y: -0.014781012199819088
-        Z: 0.017814036458730698
+        X: -0.08059938251972198
+        Y: -0.01303559448570013
+        Z: 0.19282564520835876
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.46039697527885437
+      Pitch: 0.345398485660553
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.593582272529602
+      Yaw: 3.8685810565948486
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 882
+  Height: 860
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd000000040000000000000142000002d9fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000037000002d9000000ca00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002d9fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730100000037000002d9000000a100fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004c000000044fc0100000002fb0000000800540069006d00650100000000000004c00000026b00fffffffb0000000800540069006d0065010000000000000450000000000000000000000267000002d900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002befc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002be000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002befc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002be000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000077e0000003efc0100000002fb0000000800540069006d006501000000000000077e000002fb00fffffffb0000000800540069006d006501000000000000045000000000000000000000050d000002be00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -417,6 +186,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1216
-  X: 700
-  Y: 385
+  Width: 1918
+  X: 0
+  Y: 27

--- a/URDF_Exporter/package/launch/urdf.rviz
+++ b/URDF_Exporter/package/launch/urdf.rviz
@@ -1,5 +1,5 @@
 Panels:
-  - Class: rviz/Displays
+  - Class: rviz_default_plugins/Displays
     Help Height: 78
     Name: Displays
     Property Tree Widget:
@@ -10,21 +10,21 @@ Panels:
         - /TF1
       Splitter Ratio: 0.5
     Tree Height: 591
-  - Class: rviz/Selection
+  - Class: rviz_default_plugins/Selection
     Name: Selection
-  - Class: rviz/Tool Properties
+  - Class: rviz_default_plugins/Tool Properties
     Expanded:
       - /2D Pose Estimate1
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
     Splitter Ratio: 0.5886790156364441
-  - Class: rviz/Views
+  - Class: rviz_default_plugins/Views
     Expanded:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: rviz/Time
+  - Class: rviz_default_plugins/Time
     Experimental: false
     Name: Time
     SyncMode: 0
@@ -38,7 +38,7 @@ Visualization Manager:
   Displays:
     - Alpha: 0.5
       Cell Size: 1
-      Class: rviz/Grid
+      Class: rviz_default_plugins/Grid
       Color: 160; 160; 164
       Enabled: true
       Line Style:
@@ -55,7 +55,7 @@ Visualization Manager:
       Reference Frame: <Fixed Frame>
       Value: true
     - Alpha: 1
-      Class: rviz/RobotModel
+      Class: rviz_default_plugins/RobotModel
       Collision Enabled: false
       Enabled: true
       Links:
@@ -340,7 +340,7 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
-    - Class: rviz/TF
+    - Class: rviz_default_plugins/TF
       Enabled: false
       Frame Timeout: 15
       Frames:
@@ -362,26 +362,26 @@ Visualization Manager:
     Frame Rate: 30
   Name: root
   Tools:
-    - Class: rviz/Interact
+    - Class: rviz_default_plugins/Interact
       Hide Inactive Objects: true
-    - Class: rviz/MoveCamera
-    - Class: rviz/Select
-    - Class: rviz/FocusCamera
-    - Class: rviz/Measure
-    - Class: rviz/SetInitialPose
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+    - Class: rviz_default_plugins/SetInitialPose
       Theta std deviation: 0.2617993950843811
       Topic: /initialpose
       X std deviation: 0.5
       Y std deviation: 0.5
-    - Class: rviz/SetGoal
+    - Class: rviz_default_plugins/SetGoal
       Topic: /move_base_simple/goal
-    - Class: rviz/PublishPoint
+    - Class: rviz_default_plugins/PublishPoint
       Single click: true
       Topic: /clicked_point
   Value: true
   Views:
     Current:
-      Class: rviz/Orbit
+      Class: rviz_default_plugins/Orbit
       Distance: 0.34426525235176086
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549

--- a/URDF_Exporter/package/package.xml
+++ b/URDF_Exporter/package/package.xml
@@ -1,62 +1,21 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>fusion2urdf</name>
   <version>0.0.0</version>
-  <description>The fusion2urdf package</description>
+  <description>URDF/xacro package exported from Fusion 360 (ROS2)</description>
+  <maintainer email="user@todo.todo">user</maintainer>
+  <license>BSD</license>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="syuntoku14@todo.todo">syuntoku14</maintainer>
+  <depend>robot_state_publisher</depend>
+  <depend>joint_state_publisher_gui</depend>
+  <depend>rviz2</depend>
+  <depend>xacro</depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>ros2_control</exec_depend>
+  <exec_depend>ros2_controllers</exec_depend>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/fusion2urdf</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rospy</build_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <exec_depend>rospy</exec_depend>
-
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/URDF_Exporter/utils/utils.py
+++ b/URDF_Exporter/utils/utils.py
@@ -174,9 +174,9 @@ def update_package_xml(save_dir, package_name):
     file_name = save_dir + '/package.xml'
 
     for line in fileinput.input(file_name, inplace=True):
-        if '<name>' in line:
+        if '<name>' in line and '</name>' in line:
             sys.stdout.write("  <name>" + package_name + "</name>\n")
         elif '<description>' in line:
-            sys.stdout.write("<description>The " + package_name + " package</description>\n")
+            sys.stdout.write("  <description>The " + package_name + " package (ROS2, exported from Fusion 360)</description>\n")
         else:
             sys.stdout.write(line)


### PR DESCRIPTION
Will migrate to Fusion:v.2606.1.36, and ROS2
  * Modify the Write.py file to adapt to the ROS2 xacro file format
  * The delete Node function does not support the `required` parameter
  * Replace the ROS1 `rviz_class_name` in urdf.rviz with the ROS2 `rviz_default_plugins/`
  * Use RViz2 to regenerate a urdf belonging to ROS2 with a new rviz configuration